### PR TITLE
Fix semver error from swfobject data

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var data = module.exports = {
     }
   },
   swfobject: {
-    versions: ['2.2', '2.1'],
+    versions: ['2.2.0', '2.1.0'],
     url: function (version) {
       return '//ajax.googleapis.com/ajax/libs/swfobject/' + version + '/swfobject.js';
     }


### PR DESCRIPTION
If you try to use this data, semver throws the error "Invalid Version: 2.1" or "Invalid Version: 2.2". Fixed to use a three-part version system so semver doesn't throw an error.